### PR TITLE
extend from base class

### DIFF
--- a/Heron/Convert.cs
+++ b/Heron/Convert.cs
@@ -46,8 +46,7 @@ namespace Heron
 
         public static Transform ToWGSxf()
         {
-            EarthAnchorPoint eap = new EarthAnchorPoint();
-            eap = Rhino.RhinoDoc.ActiveDoc.EarthAnchorPoint;
+            EarthAnchorPoint eap = Rhino.RhinoDoc.ActiveDoc.EarthAnchorPoint;
             Rhino.UnitSystem us = new Rhino.UnitSystem();
             Transform xf = eap.GetModelToEarthTransform(us);
 

--- a/Heron/DDtoXY.cs
+++ b/Heron/DDtoXY.cs
@@ -31,12 +31,12 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class DDtoXY : GH_Component
+    public class DDtoXY : HeronComponent
     {
         //Class Constructor
-        public DDtoXY() : base("Decimal Degrees to XY","DDtoXY","Convert Decimal Degrees Longitude/Latitude to X/Y","Heron","GIS Tools")
-        { 
-        
+        public DDtoXY() : base("Decimal Degrees to XY", "DDtoXY", "Convert Decimal Degrees Longitude/Latitude to X/Y", "GIS Tools")
+        {
+
         }
 
 
@@ -64,7 +64,7 @@ namespace Heron
             /// We'll start by declaring variables and assigning them starting values.
             double lat = -1;
             double lon = -1;
-            
+
             /// Then we need to access the input parameters individually. 
             /// When data cannot be extracted from a parameter, we should abort this method.
             if (!DA.GetData("Latitude", ref lat)) return;
@@ -81,7 +81,7 @@ namespace Heron
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Longitude should be between -180.0 deg and 180.0 deg");
                 return;
             }
-            
+
             /// Finally assign the point to the output parameter.
             DA.SetData("xyPoint", Heron.Convert.ToXYZ(new Point3d(lon, lat, 0)));
         }

--- a/Heron/Heron.csproj
+++ b/Heron/Heron.csproj
@@ -78,6 +78,7 @@
   <ItemGroup>
     <Compile Include="Convert.cs" />
     <Compile Include="GdalConfiguration.cs" />
+    <Compile Include="HeronComponent.cs" />
     <Compile Include="HeronInfo.cs" />
     <Compile Include="ImportSHP.cs" />
     <Compile Include="ImportVector.cs" />

--- a/Heron/HeronComponent.cs
+++ b/Heron/HeronComponent.cs
@@ -1,0 +1,17 @@
+﻿using Grasshopper.Kernel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Heron
+{
+    public abstract class HeronComponent : GH_Component
+    {
+        public HeronComponent(string name, string nickName, string description, string subCategory) : base(name, nickName, description, "Heron", subCategory)
+        {
+
+        }
+    }
+}

--- a/Heron/ImportTopo.cs
+++ b/Heron/ImportTopo.cs
@@ -29,12 +29,12 @@ using OSGeo.OGR;
 
 namespace Heron
 {
-    public class ImportTopo : GH_Component
+    public class ImportTopo : HeronComponent
     {
         //Class Constructor
-        public ImportTopo() : base("Import Topo","ImportTopo","Create a topographic mesh from an IMG, HGT, ASCII file clipped to a boundary","Heron","GIS Tools")
-        { 
-        
+        public ImportTopo() : base("Import Topo", "ImportTopo", "Create a topographic mesh from an IMG, HGT, ASCII file clipped to a boundary", "GIS Tools")
+        {
+
         }
 
 
@@ -49,14 +49,14 @@ namespace Heron
         {
             pManager.AddMeshParameter("topoMesh", "topoMesh", "Resultant topographic mesh from IMG or HGT file", GH_ParamAccess.tree);
             pManager.AddRectangleParameter("topoExtent", "topoExtent", "Bounding box for the entire IMG or HGT file", GH_ParamAccess.item);
-            
+
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)
         {
             List<Curve> boundary = new List<Curve>();
             DA.GetDataList<Curve>(0, boundary);
-            
+
             string IMG_file = "";
             DA.GetData<string>("IMG Location", ref IMG_file);
             /*  
@@ -112,7 +112,7 @@ namespace Heron
 
                 else
                 {
-                    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Data source SRS: EPSG:"+sr.GetAttrValue("AUTHORITY",1));
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Data source SRS: EPSG:" + sr.GetAttrValue("AUTHORITY", 1));
                 }
             }
 
@@ -139,7 +139,7 @@ namespace Heron
 
             ///Transform to WGS84
             double[] extMinPT = new double[3] { oX, eY, 0 };
-            double[] extMaxPT = new double[3] { eX, oY, 0};
+            double[] extMaxPT = new double[3] { eX, oY, 0 };
             coordTransform.TransformPoint(extMinPT);
             coordTransform.TransformPoint(extMaxPT);
             Point3d dsMin = new Point3d(extMinPT[0], extMinPT[1], extMinPT[2]);
@@ -159,7 +159,7 @@ namespace Heron
             {
                 if (dsbox.BoundingBox.Contains(boundary[i].GetBoundingBox(true).Min) && (dsbox.BoundingBox.Contains(boundary[i].GetBoundingBox(true).Max)))
                 {
-                    
+
                     Point3d min = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Corner(true, false, true));
                     Point3d max = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Corner(false, true, true));
 
@@ -211,7 +211,7 @@ namespace Heron
                             double[] wgsPT = new double[3] { gcol, grow, pixel };
                             coordTransform.TransformPoint(wgsPT);
                             Point3d pt = new Point3d(wgsPT[0], wgsPT[1], wgsPT[2]);
-                            
+
                             //Point3d pt = new Point3d(gcol, grow, pixel);
                             verts.Add(Heron.Convert.ToXYZ(pt));
                         }
@@ -232,7 +232,7 @@ namespace Heron
                                 vertsParallel[] = Heron.Convert.ToXYZ(pt);
                             });
                          * */
-                         
+
                     }
 
                     //Create meshes

--- a/Heron/ImportVector.cs
+++ b/Heron/ImportVector.cs
@@ -29,10 +29,10 @@ using OSGeo.OGR;
 
 namespace Heron
 {
-    public class ImportVector : GH_Component
+    public class ImportVector : HeronComponent
     {
         //Class Constructor
-        public ImportVector() : base("Import Vector", "ImportVector", "Import vector GIS data clipped to a boundary, including SHP, GeoJSON, OSM, KML, MVT and GDB folders.", "Heron", "GIS Tools")
+        public ImportVector() : base("Import Vector", "ImportVector", "Import vector GIS data clipped to a boundary, including SHP, GeoJSON, OSM, KML, MVT and GDB folders.", "GIS Tools")
         {
 
         }

--- a/Heron/RESTGeocode.cs
+++ b/Heron/RESTGeocode.cs
@@ -28,19 +28,19 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class RESTGeocode : GH_Component
+    public class RESTGeocode : HeronComponent
     {
         //Class Constructor
-        public RESTGeocode() : base("ESRI REST Service Geocode","RESTGeocode","Get coordinates based on a Point-of-Interest or Address","Heron","GIS REST")
-        { 
-        
+        public RESTGeocode() : base("ESRI REST Service Geocode", "RESTGeocode", "Get coordinates based on a Point-of-Interest or Address", "GIS REST")
+        {
+
         }
 
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
             pManager.AddTextParameter("Addresses", "addresses", "POI or Address string(s) to geocode", GH_ParamAccess.tree);
-            
+
         }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
@@ -48,7 +48,7 @@ namespace Heron
             pManager.AddTextParameter("Candidates", "Candidates", "List of Candidate locations", GH_ParamAccess.tree);
             pManager.AddTextParameter("Latitude", "LAT", "Latitude of Candidate location", GH_ParamAccess.tree);
             pManager.AddTextParameter("Longitude", "LON", "Longitude of Candidate location", GH_ParamAccess.tree);
-            
+
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)
@@ -84,7 +84,7 @@ namespace Heron
                         {
                             if (ja["candidates"][i]["score"].Value<int>() > 99)
                             {
-                                addr.Append(new GH_String(ja["candidates"][i]["address"].ToString()), new GH_Path(path[count],i));
+                                addr.Append(new GH_String(ja["candidates"][i]["address"].ToString()), new GH_Path(path[count], i));
                                 addr.Append(new GH_String("LON: " + ja["candidates"][i]["location"]["x"].ToString()), new GH_Path(path[count], i));
                                 addr.Append(new GH_String("LAT: " + ja["candidates"][i]["location"]["y"].ToString()), new GH_Path(path[count], i));
                                 lony.Append(new GH_String(ja["candidates"][i]["location"]["y"].ToString()), new GH_Path(path[count], i));

--- a/Heron/RESTLayer.cs
+++ b/Heron/RESTLayer.cs
@@ -28,19 +28,19 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class RESTLayer : GH_Component
+    public class RESTLayer : HeronComponent
     {
         //Class Constructor
-        public RESTLayer() : base("Get REST Service Layers","RESTLayer","Discover ArcGIS REST Service Layers","Heron","GIS REST")
-        { 
-        
+        public RESTLayer() : base("Get REST Service Layers", "RESTLayer", "Discover ArcGIS REST Service Layers", "GIS REST")
+        {
+
         }
 
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
             pManager.AddTextParameter("Service URL", "serviceURL", "Service URL string", GH_ParamAccess.item);
-            
+
         }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
@@ -48,51 +48,52 @@ namespace Heron
             pManager.AddTextParameter("Map Description", "mapDescription", "Description of the REST Service", GH_ParamAccess.item);
             pManager.AddTextParameter("Map Layer", "mapLayers", "Names of available Service Layers", GH_ParamAccess.list);
             pManager.AddIntegerParameter("Map Integer", "mapIndex", "Index of available Service Layers", GH_ParamAccess.list);
-            
+
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)
         {
             string URL = "";
-                       
+
             DA.GetData<string>("Service URL", ref URL);
 
-    //get json from rest service
-    string restquery = URL + "?f=pjson";
+            //get json from rest service
+            string restquery = URL + "?f=pjson";
 
-    System.Net.HttpWebRequest req = System.Net.WebRequest.Create(restquery) as System.Net.HttpWebRequest;
-    string result = null;
+            System.Net.HttpWebRequest req = System.Net.WebRequest.Create(restquery) as System.Net.HttpWebRequest;
+            string result = null;
 
-    using (System.Net.HttpWebResponse resp = req.GetResponse() as System.Net.HttpWebResponse)
-    {
-      System.IO.StreamReader reader = new System.IO.StreamReader(resp.GetResponseStream());
-      result = reader.ReadToEnd();
-      reader.Close();
-    }
+            using (System.Net.HttpWebResponse resp = req.GetResponse() as System.Net.HttpWebResponse)
+            {
+                System.IO.StreamReader reader = new System.IO.StreamReader(resp.GetResponseStream());
+                result = reader.ReadToEnd();
+                reader.Close();
+            }
 
-    //parse json into a description and list of layer values
-    JObject j = JObject.Parse(result);
-    List<string> layerKey = new List<string>();
-    List<int> layerInt = new List<int>();
+            //parse json into a description and list of layer values
+            JObject j = JObject.Parse(result);
+            List<string> layerKey = new List<string>();
+            List<int> layerInt = new List<int>();
 
-    Dictionary<string, int> d = new Dictionary<string, int>();
+            Dictionary<string, int> d = new Dictionary<string, int>();
 
-    for (int i = 1; i < j["layers"].Children()["name"].Count(); i++){
-      d[(string) j["layers"][i]["name"]] = (int) j["layers"][i]["id"];
-      layerKey.Add((string) j["layers"][i]["name"]);
-      layerInt.Add((int) j["layers"][i]["id"]);
-    }
+            for (int i = 1; i < j["layers"].Children()["name"].Count(); i++)
+            {
+                d[(string)j["layers"][i]["name"]] = (int)j["layers"][i]["id"];
+                layerKey.Add((string)j["layers"][i]["name"]);
+                layerInt.Add((int)j["layers"][i]["id"]);
+            }
 
-    DA.SetData("Map Description", (string)j["description"]);
-    //mapDescription = (string) j["description"];
-    DA.SetDataList("Map Layer", layerKey);
-    //mapLayer = layerKey;
-    DA.SetDataList("Map Integer", layerInt);
-    //mapInt = layerInt;
+            DA.SetData("Map Description", (string)j["description"]);
+            //mapDescription = (string) j["description"];
+            DA.SetDataList("Map Layer", layerKey);
+            //mapLayer = layerKey;
+            DA.SetDataList("Map Integer", layerInt);
+            //mapInt = layerInt;
 
         }
 
-  
+
 
         protected override System.Drawing.Bitmap Icon
         {

--- a/Heron/RESTRaster.cs
+++ b/Heron/RESTRaster.cs
@@ -31,12 +31,12 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class RESTRaster : GH_Component
+    public class RESTRaster : HeronComponent
     {
         //Class Constructor
-        public RESTRaster() : base("Get REST Raster","RESTRaster","Get raster imagery from ArcGIS REST Services","Heron","GIS REST")
-        { 
-        
+        public RESTRaster() : base("Get REST Raster", "RESTRaster", "Get raster imagery from ArcGIS REST Services", "GIS REST")
+        {
+
         }
 
 
@@ -48,7 +48,7 @@ namespace Heron
             pManager.AddTextParameter("Prefix", "prefix", "Prefix for image file name", GH_ParamAccess.item);
             pManager.AddTextParameter("REST URL", "URL", "ArcGIS REST Service website to query", GH_ParamAccess.item);
             pManager.AddBooleanParameter("run", "get", "Go ahead and download imagery from the Service", GH_ParamAccess.item, false);
-            
+
         }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
@@ -56,7 +56,7 @@ namespace Heron
             pManager.AddTextParameter("image", "Image", "File location of downloaded image", GH_ParamAccess.tree);
             pManager.AddCurveParameter("imageFrame", "imageFrame", "Bounding box of image for mapping to geometry", GH_ParamAccess.tree);
             pManager.AddTextParameter("RESTQuery", "RESTQuery", "Full text of REST query", GH_ParamAccess.tree);
-            
+
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)
@@ -126,7 +126,7 @@ namespace Heron
                     webClient.DownloadFile(restquery, fileloc + prefix + "_" + i + ".jpg");
                     webClient.Dispose();
                 }
-                mapList.Append(new GH_String(fileloc + prefix +"_" + i + ".jpg"), path);
+                mapList.Append(new GH_String(fileloc + prefix + "_" + i + ".jpg"), path);
                 mapquery.Append(new GH_String(restquery), path);
             }
 

--- a/Heron/RESTRevGeo.cs
+++ b/Heron/RESTRevGeo.cs
@@ -34,19 +34,19 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class RESTRevGeo : GH_Component
+    public class RESTRevGeo : HeronComponent
     {
         //Class Constructor
-        public RESTRevGeo() : base("ESRI REST Service Reverse Geocode","RESTRevGeo","Get the closest addresses to XY coordinates","Heron","GIS REST")
-        { 
-        
+        public RESTRevGeo() : base("ESRI REST Service Reverse Geocode", "RESTRevGeo", "Get the closest addresses to XY coordinates", "GIS REST")
+        {
+
         }
 
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
             pManager.AddPointParameter("XY", "xyPoint", "Points for which to find addresses", GH_ParamAccess.tree);
-            
+
         }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
@@ -59,7 +59,7 @@ namespace Heron
             pManager.AddTextParameter("Country", "Country", "Country", GH_ParamAccess.tree);
             pManager.AddTextParameter("LAT", "LAT", "Latitude", GH_ParamAccess.tree);
             pManager.AddTextParameter("LON", "LON", "Longitude", GH_ParamAccess.tree);
-            
+
         }
 
         public delegate JObject jsonDelegate(string delegString);
@@ -74,7 +74,7 @@ namespace Heron
         GH_Structure<GH_String> latTree = new GH_Structure<GH_String>();
         GH_Structure<GH_String> lonTree = new GH_Structure<GH_String>();
          * */
-        
+
         //add "async" after override to make asynchronous
         protected override void SolveInstance(IGH_DataAccess DA)
         {
@@ -102,11 +102,11 @@ namespace Heron
                 {
                     Point3d geopt = Heron.Convert.ToWGS(pt.Value);
                     string webrequest = "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?location=" + geopt.X + "%2C+" + geopt.Y + "&distance=200&outSR=&f=pjson";
-                    
+
                     //Synchronous method
                     string output = GetData("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?location=" + geopt.X + "%2C+" + geopt.Y + "&distance=200&outSR=&f=pjson");
                     JObject ja = JObject.Parse(output);
-                    
+
                     //Delegate method
                     //IAsyncResult jaInvoke = del.BeginInvoke(webrequest, null, null);
                     //JObject ja = del.EndInvoke(jaInvoke);
@@ -115,14 +115,14 @@ namespace Heron
                     //JObject ja = await GetAsync("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?location=" + geopt.X + "%2C+" + geopt.Y + "&distance=200&outSR=&f=pjson");
 
 
-                            addressTree.Append(new GH_String(ja["address"]["Address"].ToString()), path);
-                            neighborhoodTree.Append(new GH_String(ja["address"]["Neighborhood"].ToString()), path);
-                            cityTree.Append(new GH_String(ja["address"]["City"].ToString()), path);
-                            regionTree.Append(new GH_String(ja["address"]["Region"].ToString()), path);
-                            postalTree.Append(new GH_String(ja["address"]["Postal"].ToString()), path);
-                            countryTree.Append(new GH_String(ja["address"]["CountryCode"].ToString()), path);
-                            latTree.Append(new GH_String(ja["location"]["y"].ToString()), path);
-                            lonTree.Append(new GH_String(ja["location"]["x"].ToString()), path);
+                    addressTree.Append(new GH_String(ja["address"]["Address"].ToString()), path);
+                    neighborhoodTree.Append(new GH_String(ja["address"]["Neighborhood"].ToString()), path);
+                    cityTree.Append(new GH_String(ja["address"]["City"].ToString()), path);
+                    regionTree.Append(new GH_String(ja["address"]["Region"].ToString()), path);
+                    postalTree.Append(new GH_String(ja["address"]["Postal"].ToString()), path);
+                    countryTree.Append(new GH_String(ja["address"]["CountryCode"].ToString()), path);
+                    latTree.Append(new GH_String(ja["location"]["y"].ToString()), path);
+                    lonTree.Append(new GH_String(ja["location"]["x"].ToString()), path);
 
                 }
             }

--- a/Heron/RESTTopo.cs
+++ b/Heron/RESTTopo.cs
@@ -13,7 +13,7 @@ using Rhino.Geometry;
 
 namespace Heron
 {
-    public class RESTTopo : GH_Component
+    public class RESTTopo : HeronComponent
     {
         /// <summary>
         /// Initializes a new instance of the MyComponent1 class.
@@ -25,7 +25,7 @@ namespace Heron
                 "Shuttle Radar Topography Mission (SRTM GL3 90m and SRTM GL1 30m), " +
                 "Advanced Land Observing Satellite (ALOS World 3D - 30m) and " +
                 "Global Multi-Resolution Topography (GMRT including bathymetry). Sources are opentopography.org and gmrt.org.",
-              "Heron", "GIS REST")
+               "GIS REST")
         {
         }
 
@@ -72,7 +72,7 @@ namespace Heron
 
             Dictionary<string, TopoServices> tServices = GetTopoServices();
 
-            GH_Structure <GH_String> demList = new GH_Structure<GH_String>();
+            GH_Structure<GH_String> demList = new GH_Structure<GH_String>();
             GH_Structure<GH_String> demQuery = new GH_Structure<GH_String>();
 
             for (int i = 0; i < boundary.Count; i++)
@@ -191,7 +191,7 @@ namespace Heron
             public string URL { get; set; }
         }
 
-        public static Dictionary<string,TopoServices> GetTopoServices()
+        public static Dictionary<string, TopoServices> GetTopoServices()
         {
             Dictionary<string, TopoServices> services = new Dictionary<string, TopoServices>()
             {
@@ -205,8 +205,8 @@ namespace Heron
             };
             return services;
         }
-       
-        
+
+
 
         private string topoService = "SRTM GL1 (30m)";
 

--- a/Heron/RESTVector.cs
+++ b/Heron/RESTVector.cs
@@ -31,12 +31,12 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class RESTVector : GH_Component
+    public class RESTVector : HeronComponent
     {
         //Class Constructor
-        public RESTVector() : base("Get REST Vector","RESTVector","Get vector data from ArcGIS REST Services","Heron","GIS REST")
-        { 
-        
+        public RESTVector() : base("Get REST Vector", "RESTVector", "Get vector data from ArcGIS REST Services", "GIS REST")
+        {
+
         }
 
 
@@ -45,7 +45,7 @@ namespace Heron
             pManager.AddCurveParameter("Boundary", "boundary", "Boundary curve(s) for vector data", GH_ParamAccess.list);
             pManager.AddTextParameter("REST URL", "URL", "ArcGIS REST Service website to query", GH_ParamAccess.item);
             pManager.AddBooleanParameter("run", "get", "Go ahead to download vector data from the Service", GH_ParamAccess.item, false);
-            
+
         }
 
         protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
@@ -111,7 +111,7 @@ namespace Heron
                     GH_Path path = new GH_Path(i, m);
 
                     //need to be able to escape this if no "geometry" property
-                    if (j[i].Property("features.["+m+"].geometry") != null)
+                    if (j[i].Property("features.[" + m + "].geometry") != null)
                     {
                         //choose type of geometry to read
                         JsonReader jreader = j[i]["features"][m]["geometry"].CreateReader();
@@ -156,7 +156,7 @@ namespace Heron
             DA.SetDataTree(3, mapquery);
 
         }
-        
+
         //Return JSON from webquery
         public static string GetData(string qst)
         {

--- a/Heron/SetEAP.cs
+++ b/Heron/SetEAP.cs
@@ -31,12 +31,12 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class SetEAP : GH_Component
+    public class SetEAP : HeronComponent
     {
         //Class Constructor
-        public SetEAP() : base("Set EarthAnchorPoint","SetEAP","Set the Rhino EarthAnchorPoint","Heron","GIS Tools")
-        { 
-        
+        public SetEAP() : base("Set EarthAnchorPoint", "SetEAP", "Set the Rhino EarthAnchorPoint", "GIS Tools")
+        {
+
         }
 
 

--- a/Heron/XYtoDD.cs
+++ b/Heron/XYtoDD.cs
@@ -31,12 +31,12 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class XYtoDD : GH_Component
+    public class XYtoDD : HeronComponent
     {
         //Class Constructor
-        public XYtoDD() : base("XY to Decimal Degrees","XYtoDD","Convert X/Y to Decimal Degrees Longitude/Latitude","Heron","GIS Tools")
-        { 
-        
+        public XYtoDD() : base("XY to Decimal Degrees", "XYtoDD", "Convert X/Y to Decimal Degrees Longitude/Latitude", "GIS Tools")
+        {
+
         }
 
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)


### PR DESCRIPTION
One pattern I have grown to really like in GH plugin development is to have all components extend from a common library base class. This PR creates a HeronComponent class that all components derive from. Currently all this takes care of is setting the component category, but this also sets up the ability to set up centralized component methods shared across components. 