### PR TITLE
Raster preview in viewport for Raster components

### DIFF
--- a/Heron/Convert.cs
+++ b/Heron/Convert.cs
@@ -306,7 +306,7 @@ namespace Heron
         }
 
         //get the range of tiles that intersect with the bounding box of the polygon
-        public static List<List<int>> GetTileRange(BoundingBox bnds, int zoom)
+        public static (Interval XRange, Interval YRange) GetTileRange(BoundingBox bnds, int zoom)
         {
             Point3d bndsMin = Convert.WorldToWGS(bnds.Min);
             Point3d bndsMax = Convert.WorldToWGS(bnds.Max);
@@ -316,9 +316,9 @@ namespace Heron
             double ymx = bndsMax.Y;
             List<int> starting = Convert.DegToNum(ymx, xm, zoom);
             List<int> ending = Convert.DegToNum(ym, xmx, zoom);
-            List<int> x_range = new List<int> { starting[0], ending[0] };
-            List<int> y_range = new List<int> { starting[1], ending[1] };
-            return new List<List<int>> { x_range, y_range };
+            var x_range = new Interval(starting[0], ending[0]);
+            var y_range = new Interval(starting[1], ending[1]);
+            return (x_range, y_range);
         }
 
         //get the tile as a polyline object

--- a/Heron/DDtoXY.cs
+++ b/Heron/DDtoXY.cs
@@ -58,7 +58,7 @@ namespace Heron
         protected override void SolveInstance(IGH_DataAccess DA)
         {
             ///Dump out the transform first
-            DA.SetData("Transform", Heron.Convert.ToXYZxf());
+            DA.SetData("Transform", Heron.Convert.WGSToWorldTransform());
 
             /// Then, we need to retrieve all data from the input parameters.
             /// We'll start by declaring variables and assigning them starting values.
@@ -83,7 +83,7 @@ namespace Heron
             }
 
             /// Finally assign the point to the output parameter.
-            DA.SetData("xyPoint", Heron.Convert.ToXYZ(new Point3d(lon, lat, 0)));
+            DA.SetData("xyPoint", Heron.Convert.WGSToWorld(new Point3d(lon, lat, 0)));
         }
 
         protected override System.Drawing.Bitmap Icon

--- a/Heron/Heron.csproj
+++ b/Heron/Heron.csproj
@@ -66,6 +66,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -80,6 +83,7 @@
     <Compile Include="GdalConfiguration.cs" />
     <Compile Include="HeronComponent.cs" />
     <Compile Include="HeronInfo.cs" />
+    <Compile Include="HeronRasterPreviewComponent.cs" />
     <Compile Include="ImportSHP.cs" />
     <Compile Include="ImportVector.cs" />
     <Compile Include="ImportTopo.cs">

--- a/Heron/HeronRasterPreviewComponent.cs
+++ b/Heron/HeronRasterPreviewComponent.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Grasshopper.Kernel;
+using Rhino.Display;
+using Rhino.DocObjects;
+using Rhino.Geometry;
+using Rhino.Render;
+
+namespace Heron
+{
+    internal struct HeronRasterPreviewItem
+    {
+        public DisplayMaterial mat;
+        public Mesh mesh;
+    }
+
+    public abstract class HeronRasterPreviewComponent : HeronComponent
+    {
+        private List<HeronRasterPreviewItem> _previewItems;
+        private BoundingBox _boundingBox;
+        public HeronRasterPreviewComponent(string name, string nickName, string description, string subCategory) : base(name, nickName, description, subCategory)
+        {
+            _previewItems = new List<HeronRasterPreviewItem>();
+        }
+
+        protected override void BeforeSolveInstance()
+        {
+            _previewItems.Clear();
+            _boundingBox = BoundingBox.Empty;
+        }
+
+        internal static Rectangle3d BBoxToRect(BoundingBox imageBox)
+        {
+            var xInterval = new Interval(imageBox.Min.X, imageBox.Max.X);
+            var yInterval = new Interval(imageBox.Min.Y, imageBox.Max.Y);
+            var rect = new Rectangle3d(Plane.WorldXY, xInterval, yInterval);
+            return rect;
+        }
+
+        public override bool IsPreviewCapable => true;
+
+        internal void AddPreviewItem(string bitmap, Rectangle3d bounds)
+        {
+            AddPreviewItem(bitmap, bounds.ToNurbsCurve(), bounds);
+        }
+
+        internal void AddPreviewItem(string bitmap, Curve c, Rectangle3d bounds)
+        {
+            var mesh = Mesh.CreateFromPlanarBoundary(c, MeshingParameters.FastRenderMesh, 0.1);
+            TextureMapping tm = TextureMapping.CreatePlaneMapping(bounds.Plane, bounds.X, bounds.Y, new Interval(-1, 1));
+            mesh.SetTextureCoordinates(tm, Transform.Identity, true);
+            var mat = new DisplayMaterial(System.Drawing.Color.White);
+            mat.SetBitmapTexture(bitmap, true);
+            _previewItems.Add(new HeronRasterPreviewItem()
+            {
+                mesh = mesh,
+                mat = mat
+            });
+        }
+
+        public override void DrawViewportMeshes(IGH_PreviewArgs args)
+        {
+            foreach (var item in _previewItems)
+            {
+                args.Display.DrawMeshShaded(item.mesh, item.mat);
+            }
+            base.DrawViewportMeshes(args);
+        }
+
+    }
+}

--- a/Heron/ImportSHP.cs
+++ b/Heron/ImportSHP.cs
@@ -125,7 +125,7 @@ namespace Heron
             coordTransform.TransformPoint(extMaxPT);
             Point3d extPTmin = new Point3d(extMinPT[0], extMinPT[1], extMinPT[2]);
             Point3d extPTmax = new Point3d(extMaxPT[0], extMaxPT[1], extMaxPT[2]);
-            Rectangle3d rec = new Rectangle3d(Plane.WorldXY, Heron.Convert.ToXYZ(extPTmin), Heron.Convert.ToXYZ(extPTmax));
+            Rectangle3d rec = new Rectangle3d(Plane.WorldXY, Heron.Convert.WGSToWorld(extPTmin), Heron.Convert.WGSToWorld(extPTmax));
 
             //Declare trees
             GH_Structure<GH_String> fset = new GH_Structure<GH_String>();
@@ -140,8 +140,8 @@ namespace Heron
                 {
 
                     //Create bounding box for clipping geometry
-                    Point3d min = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Min);
-                    Point3d max = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Max);
+                    Point3d min = Heron.Convert.WorldToWGS(boundary[i].GetBoundingBox(true).Min);
+                    Point3d max = Heron.Convert.WorldToWGS(boundary[i].GetBoundingBox(true).Max);
                     double[] minpT = new double[3];
                     double[] maxpT = new double[3];
 
@@ -194,7 +194,7 @@ namespace Heron
                                 pt3D.Y = pT[1];
                                 pt3D.Z = pT[2];
 
-                                gset.Append(new GH_Point(Heron.Convert.ToXYZ(pt3D)), new GH_Path(i, m));
+                                gset.Append(new GH_Point(Heron.Convert.WGSToWorld(pt3D)), new GH_Path(i, m));
                                 //End loop through geometry points
 
                                 // Get Feature Values
@@ -238,7 +238,7 @@ namespace Heron
                                     pt3D.Y = pT[1];
                                     pt3D.Z = pT[2];
 
-                                    gset.Append(new GH_Point(Heron.Convert.ToXYZ(pt3D)), new GH_Path(i, m, gi));
+                                    gset.Append(new GH_Point(Heron.Convert.WGSToWorld(pt3D)), new GH_Path(i, m, gi));
                                     //End loop through geometry points
 
                                     // Get Feature Values

--- a/Heron/ImportTopo.cs
+++ b/Heron/ImportTopo.cs
@@ -147,7 +147,7 @@ namespace Heron
 
             //Point3d dsMin = new Point3d(oX, eY, 0);
             //Point3d dsMax = new Point3d(eX, oY, 0);
-            Rectangle3d dsbox = new Rectangle3d(Plane.WorldXY, Heron.Convert.ToXYZ(dsMin), Heron.Convert.ToXYZ(dsMax));
+            Rectangle3d dsbox = new Rectangle3d(Plane.WorldXY, Heron.Convert.WGSToWorld(dsMin), Heron.Convert.WGSToWorld(dsMax));
 
             //Declare trees
             GH_Structure<GH_Point> pointcloud = new GH_Structure<GH_Point>();
@@ -160,8 +160,8 @@ namespace Heron
                 if (dsbox.BoundingBox.Contains(boundary[i].GetBoundingBox(true).Min) && (dsbox.BoundingBox.Contains(boundary[i].GetBoundingBox(true).Max)))
                 {
 
-                    Point3d min = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Corner(true, false, true));
-                    Point3d max = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Corner(false, true, true));
+                    Point3d min = Heron.Convert.WorldToWGS(boundary[i].GetBoundingBox(true).Corner(true, false, true));
+                    Point3d max = Heron.Convert.WorldToWGS(boundary[i].GetBoundingBox(true).Corner(false, true, true));
 
                     ///Transform to source SRS
                     double[] minR = new double[3] { min.X, min.Y, min.Z };
@@ -213,7 +213,7 @@ namespace Heron
                             Point3d pt = new Point3d(wgsPT[0], wgsPT[1], wgsPT[2]);
 
                             //Point3d pt = new Point3d(gcol, grow, pixel);
-                            verts.Add(Heron.Convert.ToXYZ(pt));
+                            verts.Add(Heron.Convert.WGSToWorld(pt));
                         }
 
                         /*Parallel.For(Urow, Lrow - 1, rowP =>

--- a/Heron/ImportVector.cs
+++ b/Heron/ImportVector.cs
@@ -189,7 +189,7 @@ namespace Heron
                 coordTransform.TransformPoint(extMaxPT);
                 Point3d extPTmin = new Point3d(extMinPT[0], extMinPT[1], extMinPT[2]);
                 Point3d extPTmax = new Point3d(extMaxPT[0], extMaxPT[1], extMaxPT[2]);
-                Rectangle3d rec = new Rectangle3d(Plane.WorldXY, Heron.Convert.ToXYZ(extPTmin), Heron.Convert.ToXYZ(extPTmax));
+                Rectangle3d rec = new Rectangle3d(Plane.WorldXY, Heron.Convert.WGSToWorld(extPTmin), Heron.Convert.WGSToWorld(extPTmax));
                 recs.Append(new GH_Rectangle(rec), new GH_Path(iLayer));
 
 
@@ -239,8 +239,8 @@ namespace Heron
                     else
                     {
                         ///Create bounding box for clipping geometry
-                        Point3d min = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Min);
-                        Point3d max = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Max);
+                        Point3d min = Heron.Convert.WorldToWGS(boundary[i].GetBoundingBox(true).Min);
+                        Point3d max = Heron.Convert.WorldToWGS(boundary[i].GetBoundingBox(true).Max);
                         double[] minpT = new double[3];
                         double[] maxpT = new double[3];
 
@@ -299,7 +299,7 @@ namespace Heron
                                     pt3D.Y = pT[1];
                                     pt3D.Z = pT[2];
 
-                                    gset.Append(new GH_Point(Heron.Convert.ToXYZ(pt3D)), new GH_Path(i, iLayer, m));
+                                    gset.Append(new GH_Point(Heron.Convert.WGSToWorld(pt3D)), new GH_Path(i, iLayer, m));
                                     ///End loop through geometry points
 
                                     /// Get Feature Values
@@ -354,7 +354,7 @@ namespace Heron
                                                 pt3D.Y = pT[1];
                                                 pt3D.Z = pT[2];
 
-                                                gset.Append(new GH_Point(Heron.Convert.ToXYZ(pt3D)), new GH_Path(i, iLayer, m, gi, n));
+                                                gset.Append(new GH_Point(Heron.Convert.WGSToWorld(pt3D)), new GH_Path(i, iLayer, m, gi, n));
                                                 ///End loop through geometry points
                                             }
                                             subsub_geom.Dispose();
@@ -376,7 +376,7 @@ namespace Heron
                                             pt3D.Y = pT[1];
                                             pt3D.Z = pT[2];
 
-                                            gset.Append(new GH_Point(Heron.Convert.ToXYZ(pt3D)), new GH_Path(i, iLayer, m, gi));
+                                            gset.Append(new GH_Point(Heron.Convert.WGSToWorld(pt3D)), new GH_Path(i, iLayer, m, gi));
                                             ///End loop through geometry points
                                         }
                                     }

--- a/Heron/RESTRaster.cs
+++ b/Heron/RESTRaster.cs
@@ -105,8 +105,8 @@ namespace Heron
                 //Get image frame for given boundary
                 BoundingBox imageBox = boundary[i].GetBoundingBox(false);
 
-                Point3d min = Heron.Convert.ToWGS(imageBox.Min);
-                Point3d max = Heron.Convert.ToWGS(imageBox.Max);
+                Point3d min = Heron.Convert.WorldToWGS(imageBox.Min);
+                Point3d max = Heron.Convert.WorldToWGS(imageBox.Max);
                 List<Point3d> imageCorners = imageBox.GetCorners().ToList();
                 imageCorners.Add(imageCorners[0]);
                 Polyline bpoly = new Polyline(imageCorners);

--- a/Heron/RESTRaster.cs
+++ b/Heron/RESTRaster.cs
@@ -31,7 +31,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class RESTRaster : HeronComponent
+    public class RESTRaster : HeronRasterPreviewComponent
     {
         //Class Constructor
         public RESTRaster() : base("Get REST Raster", "RESTRaster", "Get raster imagery from ArcGIS REST Services", "GIS REST")
@@ -86,7 +86,7 @@ namespace Heron
 
             GH_Structure<GH_String> mapList = new GH_Structure<GH_String>();
             GH_Structure<GH_String> mapquery = new GH_Structure<GH_String>();
-            GH_Structure<GH_ObjectWrapper> imgFrame = new GH_Structure<GH_ObjectWrapper>();
+            GH_Structure<GH_Rectangle> imgFrame = new GH_Structure<GH_Rectangle>();
 
             FileInfo file = new FileInfo(fileloc);
             file.Directory.Create();
@@ -107,11 +107,9 @@ namespace Heron
 
                 Point3d min = Heron.Convert.WorldToWGS(imageBox.Min);
                 Point3d max = Heron.Convert.WorldToWGS(imageBox.Max);
-                List<Point3d> imageCorners = imageBox.GetCorners().ToList();
-                imageCorners.Add(imageCorners[0]);
-                Polyline bpoly = new Polyline(imageCorners);
+                Rectangle3d rect = BBoxToRect(imageBox);
 
-                imgFrame.Append(new GH_ObjectWrapper(bpoly), path);
+                imgFrame.Append(new GH_Rectangle(rect), path);
 
                 //Query the REST service
                 string restquery = URL +
@@ -126,7 +124,9 @@ namespace Heron
                     webClient.DownloadFile(restquery, fileloc + prefix + "_" + i + ".jpg");
                     webClient.Dispose();
                 }
-                mapList.Append(new GH_String(fileloc + prefix + "_" + i + ".jpg"), path);
+                var bitmapPath = fileloc + prefix + "_" + i + ".jpg";
+                mapList.Append(new GH_String(bitmapPath), path);
+                AddPreviewItem(bitmapPath, rect);
                 mapquery.Append(new GH_String(restquery), path);
             }
 
@@ -136,7 +136,6 @@ namespace Heron
 
 
         }
-
 
         protected override System.Drawing.Bitmap Icon
         {

--- a/Heron/RESTRevGeo.cs
+++ b/Heron/RESTRevGeo.cs
@@ -100,7 +100,7 @@ namespace Heron
                 GH_Path path = xyz.Paths[a];
                 foreach (GH_Point pt in branch)
                 {
-                    Point3d geopt = Heron.Convert.ToWGS(pt.Value);
+                    Point3d geopt = Heron.Convert.WorldToWGS(pt.Value);
                     string webrequest = "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?location=" + geopt.X + "%2C+" + geopt.Y + "&distance=200&outSR=&f=pjson";
 
                     //Synchronous method

--- a/Heron/RESTTopo.cs
+++ b/Heron/RESTTopo.cs
@@ -92,8 +92,8 @@ namespace Heron
                 Curve offsetB = boundary[i].Offset(Plane.WorldXY, offsetD, 1, CurveOffsetCornerStyle.Sharp)[0];
 
                 //Get dem frame for given boundary
-                Point3d min = Heron.Convert.ToWGS(offsetB.GetBoundingBox(true).Min);
-                Point3d max = Heron.Convert.ToWGS(offsetB.GetBoundingBox(true).Max);
+                Point3d min = Heron.Convert.WorldToWGS(offsetB.GetBoundingBox(true).Min);
+                Point3d max = Heron.Convert.WorldToWGS(offsetB.GetBoundingBox(true).Max);
 
                 //Query opentopography.org
                 //DEM types

--- a/Heron/RESTTopo.cs
+++ b/Heron/RESTTopo.cs
@@ -35,7 +35,7 @@ namespace Heron
         protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
         {
             pManager.AddCurveParameter("Boundary", "boundary", "Boundary curve(s) for imagery", GH_ParamAccess.list);
-            pManager.AddTextParameter("File Location", "fileLocation", "Folder to place image files", GH_ParamAccess.item, @"C:\temp\");
+            pManager.AddTextParameter("File Location", "fileLocation", "Folder to place image files", GH_ParamAccess.item, Path.GetTempPath());
             pManager.AddTextParameter("Prefix", "prefix", "Prefix for image file name", GH_ParamAccess.item, topoService);
             pManager.AddBooleanParameter("Run", "get", "Go ahead and download imagery from the service", GH_ParamAccess.item, false);
 

--- a/Heron/RESTVector.cs
+++ b/Heron/RESTVector.cs
@@ -85,8 +85,8 @@ namespace Heron
             {
 
                 GH_Path cpath = new GH_Path(i);
-                Point3d min = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Min);
-                Point3d max = Heron.Convert.ToWGS(boundary[i].GetBoundingBox(true).Max);
+                Point3d min = Heron.Convert.WorldToWGS(boundary[i].GetBoundingBox(true).Min);
+                Point3d max = Heron.Convert.WorldToWGS(boundary[i].GetBoundingBox(true).Max);
 
                 string restquery = URL +
                   "query?where=&text=&objectIds=&time=&geometry=" + Heron.Convert.ConvertLat(min.X, SRef) + "%2C" + Heron.Convert.ConvertLon(min.Y, SRef) + "%2C" + Heron.Convert.ConvertLat(max.X, SRef) + "%2C" + Heron.Convert.ConvertLon(max.Y, SRef) +

--- a/Heron/SlippyRaster.cs
+++ b/Heron/SlippyRaster.cs
@@ -102,6 +102,7 @@ namespace Heron
  
             bool run = false;
             DA.GetData<bool>("Run", ref run);
+            if (!run) return;
 
             GH_Structure<GH_String> mapList = new GH_Structure<GH_String>();
             GH_Structure<GH_Curve> imgFrame = new GH_Structure<GH_Curve>();

--- a/Heron/SlippyRaster.cs
+++ b/Heron/SlippyRaster.cs
@@ -34,7 +34,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace Heron
 {
-    public class SlippyRaster : HeronComponent
+    public class SlippyRaster : HeronRasterPreviewComponent
     {
         /// <summary>
         /// Initializes a new instance of the SlippyRaster class.
@@ -47,15 +47,15 @@ namespace Heron
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
+        protected override void RegisterInputParams(GH_InputParamManager pManager)
         {
 
             pManager.AddCurveParameter("Boundary", "boundary", "Boundary curve(s) for imagery", GH_ParamAccess.list);
-            pManager.AddIntegerParameter("Zoom Level", "zoom", "Slippy map zoom level. Higher zoom level is higher resolution, but takes longer to download. Max zoom is typically 19.", GH_ParamAccess.item,14);
-            pManager.AddTextParameter("File Location", "fileLoc", "Folder to place image files", GH_ParamAccess.item,@"C:\temp\");
+            pManager.AddIntegerParameter("Zoom Level", "zoom", "Slippy map zoom level. Higher zoom level is higher resolution, but takes longer to download. Max zoom is typically 19.", GH_ParamAccess.item, 14);
+            pManager.AddTextParameter("File Location", "fileLoc", "Folder to place image files", GH_ParamAccess.item, Path.GetTempPath());
             pManager.AddTextParameter("Prefix", "prefix", "Prefix for image file name", GH_ParamAccess.item, slippySource);
             //pManager.AddTextParameter("Slippy Raster URL", "slippyURL", "Slippy raster service to query", GH_ParamAccess.item);
-            pManager.AddTextParameter("Slippy Access Header", "userAgent", "A user-agent header is sometimes required for access to Slippy resources, especially OSM. This can be any string.", GH_ParamAccess.item,"");
+            pManager.AddTextParameter("Slippy Access Header", "userAgent", "A user-agent header is sometimes required for access to Slippy resources, especially OSM. This can be any string.", GH_ParamAccess.item, "");
             pManager.AddBooleanParameter("Run", "get", "Go ahead and download imagery from the service", GH_ParamAccess.item, false);
 
             Message = SlippySource;
@@ -66,7 +66,7 @@ namespace Heron
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
+        protected override void RegisterOutputParams(GH_OutputParamManager pManager)
         {
             pManager.AddTextParameter("Image File", "Image", "File location of downloaded image", GH_ParamAccess.tree);
             pManager.AddCurveParameter("Image Frame", "imageFrame", "Bounding box of image for mapping to geometry", GH_ParamAccess.tree);
@@ -82,37 +82,37 @@ namespace Heron
         protected override void SolveInstance(IGH_DataAccess DA)
         {
             List<Curve> boundary = new List<Curve>();
-            DA.GetDataList<Curve>(0, boundary);
+            DA.GetDataList(0, boundary);
 
             int zoom = -1;
-            DA.GetData<int>(1, ref zoom);
+            DA.GetData(1, ref zoom);
 
             string fileloc = "";
-            DA.GetData<string>(2, ref fileloc);
+            DA.GetData(2, ref fileloc);
             if (!fileloc.EndsWith(@"\")) fileloc = fileloc + @"\";
 
             string prefix = "";
-            DA.GetData<string>(3, ref prefix);
+            DA.GetData(3, ref prefix);
 
             string URL = slippyURL;
             //DA.GetData<string>(4, ref URL);
 
             string userAgent = "";
-            DA.GetData<string>(4, ref userAgent);
- 
+            DA.GetData(4, ref userAgent);
+
             bool run = false;
-            DA.GetData<bool>("Run", ref run);
+            DA.GetData("Run", ref run);
             if (!run) return;
 
             GH_Structure<GH_String> mapList = new GH_Structure<GH_String>();
-            GH_Structure<GH_Curve> imgFrame = new GH_Structure<GH_Curve>();
+            GH_Structure<GH_Rectangle> imgFrame = new GH_Structure<GH_Rectangle>();
             GH_Structure<GH_Integer> tCount = new GH_Structure<GH_Integer>();
 
 
-            for (int i = 0; i <boundary.Count; i++)
+            for (int i = 0; i < boundary.Count; i++)
             {
                 GH_Path path = new GH_Path(i);
-                
+
 
                 ///Get image frame for given boundary and  make sure it's valid
                 if (!boundary[i].GetBoundingBox(true).IsValid)
@@ -142,17 +142,21 @@ namespace Heron
                 List<Point3d> boxPtList = new List<Point3d>();
 
                 ///get the tile coordinates for all tiles within boundary
-                List<List<int>> ranges = new List<List<int>>();
-                ranges = Convert.GetTileRange(boundaryBox, zoom);
-
+                var ranges = Convert.GetTileRange(boundaryBox, zoom);
                 List<List<int>> tileList = new List<List<int>>();
-                List<int> x_range = ranges[0];
-                List<int> y_range = ranges[1];
+                var x_range = ranges.XRange;
+                var y_range = ranges.YRange;
+
+                if(x_range.Length > 100 || y_range.Length > 100)
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "This tile range is too big. Check your units.");
+                    return;
+                }
 
                 ///cycle through tiles to get bounding box
-                for (int y = y_range[0]; y <= y_range[1]; y++)
+                for (int y = (int)y_range.Min; y <= y_range.Max; y++)
                 {
-                    for (int x = x_range[0]; x <= x_range[1]; x++)
+                    for (int x = (int)x_range.Min; x <= x_range.Max; x++)
                     {
                         ///add bounding box of tile to list
                         boxPtList.AddRange(Convert.GetTileAsPolygon(zoom, y, x).ToList());
@@ -161,12 +165,12 @@ namespace Heron
                 }
 
                 ///bounding box of tile boundaries
-                BoundingBox bboxPts = new BoundingBox(boxPtList);
+                BoundingBox bbox = new BoundingBox(boxPtList);
 
-                ///convert bounding box to polyline
-                List<Point3d> imageCorners = bboxPts.GetCorners().ToList();
-                imageCorners.Add(imageCorners[0]);
-                imgFrame.Append(new GH_Curve(new Rhino.Geometry.Polyline(imageCorners).ToNurbsCurve()), path);
+                var rect = BBoxToRect(bbox);
+                imgFrame.Append(new GH_Rectangle(rect), path);
+
+                AddPreviewItem(imgPath, boundary[i], rect);
 
                 ///tile range as string for (de)serialization of TileCacheMeta
                 string tileRangeString = zoom.ToString()
@@ -191,7 +195,7 @@ namespace Heron
                             imageT.Dispose();
 
                             ///check to see if tilerange in comments matches current tilerange
-                            if (imgComment== (slippySource.Replace(" ", "") + tileRangeString))
+                            if (imgComment == (slippySource.Replace(" ", "") + tileRangeString))
                             {
                                 AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Using existing image.");
                                 continue;
@@ -209,12 +213,12 @@ namespace Heron
                 ///download all tiles within boundary
                 ///merge tiles into one bitmap
                 ///API to query
-  
+
 
                 ///Do the work of assembling image
                 ///setup final image container bitmap
-                int fImageW = (x_range[1] - x_range[0] + 1) * 256;
-                int fImageH = (y_range[1] - y_range[0] + 1) * 256;
+                int fImageW = ((int)x_range.Length + 1) * 256;
+                int fImageH = ((int)y_range.Length + 1) * 256;
                 Bitmap finalImage = new Bitmap(fImageW, fImageH);
 
 
@@ -226,18 +230,18 @@ namespace Heron
                     using (Graphics g = Graphics.FromImage(finalImage))
                     {
                         g.Clear(Color.Black);
-                        for (int y = y_range[0]; y <= y_range[1]; y++)
+                        for (int y = (int)y_range.Min; y <= (int)y_range.Max; y++)
                         {
-                            for (int x = x_range[0]; x <= x_range[1]; x++)
+                            for (int x = (int)x_range.Min; x <= (int)x_range.Max; x++)
                             {
                                 //create tileCache name 
-                                string tileCache = slippySource.Replace(" ","") + zoom + x + y + ".png";
-                                string tileCahceLoc = cacheLoc + tileCache;
-                                
+                                string tileCache = slippySource.Replace(" ", "") + zoom + x + y + ".png";
+                                string tileCacheLoc = cacheLoc + tileCache;
+
                                 //check cache folder to see if tile image exists locally
-                                if (File.Exists(tileCahceLoc))
+                                if (File.Exists(tileCacheLoc))
                                 {
-                                    Bitmap tmpImage = new Bitmap(Image.FromFile(tileCahceLoc));
+                                    Bitmap tmpImage = new Bitmap(Image.FromFile(tileCacheLoc));
                                     ///add tmp image to final
                                     g.DrawImage(tmpImage, imgPosW * 256, imgPosH * 256);
                                     tmpImage.Dispose();
@@ -247,14 +251,14 @@ namespace Heron
                                 {
                                     tileList.Add(new List<int> { zoom, y, x });
                                     string urlAuth = Convert.GetZoomURL(x, y, zoom, slippyURL);
-                                    
+
                                     System.Net.WebClient client = new System.Net.WebClient();
 
                                     ///insert header if required
                                     client.Headers.Add("user-agent", userAgent);
 
-                                    client.DownloadFile(urlAuth, tileCahceLoc);
-                                    Bitmap tmpImage = new Bitmap(Image.FromFile(tileCahceLoc));
+                                    client.DownloadFile(urlAuth, tileCacheLoc);
+                                    Bitmap tmpImage = new Bitmap(Image.FromFile(tileCacheLoc));
                                     client.Dispose();
 
                                     //add tmp image to final
@@ -319,7 +323,7 @@ namespace Heron
         protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown menu)
         {
 
-            if (slippySourceList =="")
+            if (slippySourceList == "")
             {
                 slippySourceList = Convert.GetEnpoints();
             }
@@ -340,14 +344,14 @@ namespace Heron
 
                 root.DropDownItems.Add(serviceName);
             }
-         
+
             menu.Items.Add(root);
-          
+
             base.AppendAdditionalComponentMenuItems(menu);
-            
+
         }
 
-        private void ServiceItemOnClick (object sender, EventArgs e)
+        private void ServiceItemOnClick(object sender, EventArgs e)
         {
             ToolStripMenuItem item = sender as ToolStripMenuItem;
             if (item == null)
@@ -368,9 +372,9 @@ namespace Heron
             ExpireSolution(true);
         }
 
-        
 
-       
+
+
 
         ///Sticky parameters
         ///https://developer.rhino3d.com/api/grasshopper/html/5f6a9f31-8838-40e6-ad37-a407be8f2c15.htm
@@ -420,7 +424,7 @@ namespace Heron
             }
         }
 
-        public override bool Write(GH_IO.Serialization.GH_IWriter writer)
+        public override bool Write(GH_IWriter writer)
         {
             writer.SetString("TileCacheMeta", TileCacheMeta);
             writer.SetString("SlippySourceList", SlippySourceList);
@@ -444,7 +448,7 @@ namespace Heron
         /// <summary>
         /// Provides an Icon for the component.
         /// </summary>
-        protected override System.Drawing.Bitmap Icon
+        protected override Bitmap Icon
         {
             get
             {

--- a/Heron/XYtoDD.cs
+++ b/Heron/XYtoDD.cs
@@ -54,7 +54,7 @@ namespace Heron
         protected override void SolveInstance(IGH_DataAccess DA)
         {
             ///Dump out the transform first
-            DA.SetData("Transform", Heron.Convert.ToWGSxf());
+            DA.SetData("Transform", Heron.Convert.WorldToWGSTransform());
 
             /// First, we need to retrieve all data from the input parameters.
             /// We'll start by declaring variables and assigning them starting values.
@@ -64,8 +64,8 @@ namespace Heron
             if (!DA.GetData<Point3d>("xyPoint", ref xyPt)) return;
 
             /// Finally assign the output parameters.
-            DA.SetData("Latitude", Heron.Convert.ToWGS(xyPt).Y);
-            DA.SetData("Longitude", Heron.Convert.ToWGS(xyPt).X);
+            DA.SetData("Latitude", Heron.Convert.WorldToWGS(xyPt).Y);
+            DA.SetData("Longitude", Heron.Convert.WorldToWGS(xyPt).X);
         }
 
         protected override System.Drawing.Bitmap Icon

--- a/Heron/packages.config
+++ b/Heron/packages.config
@@ -6,4 +6,5 @@
   <package id="Grasshopper" version="6.24.20079.23341" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="RhinoCommon" version="6.24.20079.23341" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This builds on PR #19 (So I'd wait to review this one until that one is merged)

- Cleans up `GetTileRange` to use more descriptive types rather that lists of lists of ints
- Creates a new HeronRasterPreviewComponent abstract class with raster preview functionality, and makes RestRaster and SlippyRaster inherit from this
- Does a little cleanup of unnecessary namespaces / references  (e.g. `GH_IO.Serialization.GH_IWriter` => `GH_IO.Serialization.GH_IWriter`)

