### PR TITLE
Updated TopoServices endpoints

### DIFF
--- a/Heron/RESTTopo.cs
+++ b/Heron/RESTTopo.cs
@@ -195,9 +195,9 @@ namespace Heron
         {
             Dictionary<string, TopoServices> services = new Dictionary<string, TopoServices>()
             {
-                {"SRTM GL1 (30m)", new TopoServices{ServiceName = "SRTM GL1 (30m)", ServiceDesc = "SRTM GL1 (30m) 1 Arcsecond resolution", URL = "http://opentopo.sdsc.edu/otr/getdem?demtype=SRTMGL1&west={0}&south={1}&east={2}&north={3}"} },
-                {"SRTM GL3 (90m)", new TopoServices{ServiceName = "SRTM GL3 (90m)", ServiceDesc = "SRTM GL3 (90m) 3 Arsecond resolution", URL = "http://opentopo.sdsc.edu/otr/getdem?demtype=SRTMGL3&west={0}&south={1}&east={2}&north={3}"} },
-                {"ALOS World 3D (30m)", new TopoServices{ServiceName = "ALOS World 3D (30m)", ServiceDesc = "ALOS World 3D (30m)", URL = "http://opentopo.sdsc.edu/otr/getdem?demtype=AW3D30&west={0}&south={1}&east={2}&north={3}"} },
+                {"SRTM GL1 (30m)", new TopoServices{ServiceName = "SRTM GL1 (30m)", ServiceDesc = "SRTM GL1 (30m) 1 Arcsecond resolution", URL = "https://portal.opentopography.org/API/globaldem?demtype=SRTMGL1&west={0}&south={1}&east={2}&north={3}"} },
+                {"SRTM GL3 (90m)", new TopoServices{ServiceName = "SRTM GL3 (90m)", ServiceDesc = "SRTM GL3 (90m) 3 Arsecond resolution", URL = "https://portal.opentopography.org/API/globaldem?demtype=SRTMGL3&west={0}&south={1}&east={2}&north={3}"} },
+                {"ALOS World 3D (30m)", new TopoServices{ServiceName = "ALOS World 3D (30m)", ServiceDesc = "ALOS World 3D (30m)", URL = "https://portal.opentopography.org/API/globaldem?demtype=AW3D30&west={0}&south={1}&east={2}&north={3}"} },
                 {"GMRT Max", new TopoServices{ServiceName = "GMRT Max", ServiceDesc = "GMRT Max", URL = "https://www.gmrt.org/services/GridServer?west={0}&south={1}&east={2}&north={3}&layer=topo&format=geotiff&resolution=max"} },
                 {"GMRT High", new TopoServices{ServiceName = "GMRT High", ServiceDesc = "GMRT High resolution. Will default to highest resolution if boundary is too small.", URL = "https://www.gmrt.org/services/GridServer?west={0}&south={1}&east={2}&north={3}&layer=topo&format=geotiff&resolution=high"} },
                 {"GMRT Medium", new TopoServices{ServiceName = "GMRT Medium", ServiceDesc = "GMRT Medium resolution. Will default to higher resolution if boundary is too small.", URL = "https://www.gmrt.org/services/GridServer?west={0}&south={1}&east={2}&north={3}&layer=topo&format=geotiff&resolution=med"} },

--- a/HeronServiceEndpoints.json
+++ b/HeronServiceEndpoints.json
@@ -104,17 +104,17 @@
 	[
 		{
 			"service" : "SRTM GL1 (30m)",
-			"url" : "http://opentopo.sdsc.edu/otr/getdem?demtype=SRTMGL1&west={0}&south={1}&east={2}&north={3}",
+			"url" : "https://portal.opentopography.org/API/globaldem?demtype=SRTMGL1&west={0}&south={1}&east={2}&north={3}",
 			"description" : "SRTM GL1 (30m) 1 Arcsecond resolution"
 		},
 		{
 			"service" : "SRTM GL3 (90m)",
-			"url" : "http://opentopo.sdsc.edu/otr/getdem?demtype=SRTMGL3&west={0}&south={1}&east={2}&north={3}",
+			"url" : "https://portal.opentopography.org/API/globaldem?demtype=SRTMGL3&west={0}&south={1}&east={2}&north={3}",
 			"description" : "SRTM GL3 (90m) 3 Arsecond resolution"
 		},
 		{
 			"service" : "ALOS World 3D (30m)",
-			"url" : "http://opentopo.sdsc.edu/otr/getdem?demtype=AW3D30&west={0}&south={1}&east={2}&north={3}",
+			"url" : "https://portal.opentopography.org/API/globaldem?demtype=AW3D30&west={0}&south={1}&east={2}&north={3}",
 			"description" : "ALOS World 3D (30m)"
 		},
 		{


### PR DESCRIPTION
The old SRTM and ALOS API will be (has been?!) deprecated as of September 30, 2020. 
[OpenTopography for Developers](https://opentopography.org/developers)

This is a quick fix that updates TopoServices to reflect the new API format.
[OpenTopography API1.0.0](https://portal.opentopography.org/apidocs/#/Public/getGlobalDem)

I did not update [HeronServiceEndpoints.json](https://github.com/blueherongis/Heron/blob/master/HeronServiceEndpoints.json) as I don't know how that is used, but if it is for general reference, that would want to be updated as well.