### PR TITLE
Add UserSecrets functionality

### DIFF
--- a/Heron/Heron.csproj
+++ b/Heron/Heron.csproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -53,6 +52,54 @@
     <Reference Include="laszip.net, Version=2.2.0.0, Culture=neutral, PublicKeyToken=bc50e9aa04368e1b, processorArchitecture=MSIL">
       <HintPath>..\packages\Unofficial.laszip.net.2.2.0\lib\net4\laszip.net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.6.0.0\lib\net461\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.6.0.0\lib\net461\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.6.0.0\lib\net461\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=6.0.0.1, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.6.0.1\lib\net461\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.FileExtensions.6.0.0\lib\net461\Microsoft.Extensions.Configuration.FileExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Json.6.0.0\lib\net461\Microsoft.Extensions.Configuration.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.UserSecrets, Version=6.0.0.1, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.UserSecrets.6.0.1\lib\net461\Microsoft.Extensions.Configuration.UserSecrets.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.6.0.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.6.0.0\lib\net461\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.6.0.0\lib\net461\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Physical.6.0.0\lib\net461\Microsoft.Extensions.FileProviders.Physical.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileSystemGlobbing.6.0.0\lib\net461\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.6.0.0\lib\net461\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.6.0.0\lib\net461\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.6.0.0\lib\net461\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -75,12 +122,61 @@
       <HintPath>..\packages\RhinoCommon.6.32.20340.21001\lib\net45\RhinoCommon.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.4.3.0\lib\net462\System.IO.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime, Version=4.1.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.4.3.1\lib\net462\System.Runtime.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net463\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Text.Encodings.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.6.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=6.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.6.0.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
@@ -98,12 +194,16 @@
     <Compile Include="Components\Deprecated\SlippyRaster_DEPRECATED2021114.cs" />
     <Compile Include="Components\GIS REST\RESTVector.cs" />
     <Compile Include="Components\Utilities\MultiMoveToTopo.cs" />
+    <Compile Include="HeronConfiguration.cs" />
     <Compile Include="SpeckleAsync\GH_AsyncComponent.cs" />
     <Compile Include="Components\Utilities\HexToColor.cs" />
     <Compile Include="Components\Utilities\ColorToHex.cs" />
     <Compile Include="Convert.cs" />
     <Compile Include="Components\GIS Import-Export\ExportVector.cs" />
     <Compile Include="SpeckleAsync\WorkerInstance.cs" />
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Components\GIS API\Yelp.cs" />
     <None Include="Components\GIS Tools\GdalPoligonize.cs" />
     <Compile Include="HeronBoxPreviewComponent.cs" />
@@ -232,11 +332,13 @@
     <Error Condition="!Exists('..\packages\GDAL.Plugins.2.4.4\build\net40\GDAL.Plugins.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GDAL.Plugins.2.4.4\build\net40\GDAL.Plugins.targets'))" />
     <Error Condition="!Exists('..\packages\RhinoCommon.6.32.20340.21001\build\net45\RhinoCommon.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\RhinoCommon.6.32.20340.21001\build\net45\RhinoCommon.targets'))" />
     <Error Condition="!Exists('..\packages\Grasshopper.6.32.20340.21001\build\net45\Grasshopper.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Grasshopper.6.32.20340.21001\build\net45\Grasshopper.targets'))" />
+    <Error Condition="!Exists('..\packages\System.Text.Json.6.0.2\build\System.Text.Json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Text.Json.6.0.2\build\System.Text.Json.targets'))" />
   </Target>
   <Import Project="..\packages\GDAL.Native.2.4.4\build\net40\GDAL.Native.targets" Condition="Exists('..\packages\GDAL.Native.2.4.4\build\net40\GDAL.Native.targets')" />
   <Import Project="..\packages\GDAL.Plugins.2.4.4\build\net40\GDAL.Plugins.targets" Condition="Exists('..\packages\GDAL.Plugins.2.4.4\build\net40\GDAL.Plugins.targets')" />
   <Import Project="..\packages\RhinoCommon.6.32.20340.21001\build\net45\RhinoCommon.targets" Condition="Exists('..\packages\RhinoCommon.6.32.20340.21001\build\net45\RhinoCommon.targets')" />
   <Import Project="..\packages\Grasshopper.6.32.20340.21001\build\net45\Grasshopper.targets" Condition="Exists('..\packages\Grasshopper.6.32.20340.21001\build\net45\Grasshopper.targets')" />
+  <Import Project="..\packages\System.Text.Json.6.0.2\build\System.Text.Json.targets" Condition="Exists('..\packages\System.Text.Json.6.0.2\build\System.Text.Json.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Heron/Heron.csproj
+++ b/Heron/Heron.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Heron</RootNamespace>
     <AssemblyName>Heron</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Heron/HeronConfiguration.cs
+++ b/Heron/HeronConfiguration.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Heron
+{
+    class HeronConfig
+    {
+        /// <summary>
+        /// Enable use of UserSecrets in order to keep keys/tokens off Github.  Before compiling copy appsettings.json to 
+        /// \AppData\Roaming\Microsoft\UserSecrets\6aefc65d-9849-4d4f-b9a7-16d77517db86 and rename as secrets.json.
+        /// Edit secrets.json with your own keys/tokens.
+        /// </summary>
+        public static class ServiceProviderBuilder
+        {
+            public static IServiceProvider GetServiceProvider()
+            {
+                var configuration = new ConfigurationBuilder()
+                    .SetBasePath(Directory.GetCurrentDirectory())
+                    .AddJsonFile("appsettings.json", true, true)
+                    .AddEnvironmentVariables()
+                    //.AddUserSecrets(typeof(RESTTopo).Assembly)
+                    //.AddUserSecrets<HeronConfiguration>(true,true)
+                    .AddUserSecrets("6aefc65d-9849-4d4f-b9a7-16d77517db86")
+                    .Build();
+                var services = new ServiceCollection();
+
+                services.Configure<HeronConfiguration>(configuration.GetSection(typeof(HeronConfiguration).FullName));
+
+                var provider = services.BuildServiceProvider();
+                return provider;
+            }
+        }
+
+        /// <summary>
+        /// Call LoadKeys() to load in secrets 
+        /// </summary>
+        public static void LoadKeys()
+        {
+            var services = Heron.HeronConfig.ServiceProviderBuilder.GetServiceProvider();
+            var options = services.GetRequiredService<IOptions<HeronConfiguration>>();
+
+            OpenTopographyAPIKey = options.Value.HeronOpenTopographyAPI;
+        }
+
+        public static string OpenTopographyAPIKey { get; set; }
+
+    }
+    public class HeronConfiguration
+    {
+        public string HeronOpenTopographyAPI { get; set; }
+
+    }
+
+
+}

--- a/Heron/app.config
+++ b/Heron/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="protobuf-net" publicKeyToken="257b51d87d2e4d67" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.3.7.0" newVersion="2.3.7.0" />
+        <assemblyIdentity name="protobuf-net" publicKeyToken="257b51d87d2e4d67" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.3.7.0" newVersion="2.3.7.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Heron/app.config
+++ b/Heron/app.config
@@ -1,11 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="protobuf-net" publicKeyToken="257b51d87d2e4d67" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.3.7.0" newVersion="2.3.7.0"/>
+        <assemblyIdentity name="protobuf-net" publicKeyToken="257b51d87d2e4d67" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.7.0" newVersion="2.3.7.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.2" newVersion="6.0.0.2" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" /></startup></configuration>

--- a/Heron/appsettings.json
+++ b/Heron/appsettings.json
@@ -1,0 +1,5 @@
+﻿{
+    "Heron.HeronConfiguration": {
+        "HeronOpenTopographyAPI": "<<STORE IN USERSECRETS>>"
+    }
+}

--- a/Heron/packages.config
+++ b/Heron/packages.config
@@ -4,10 +4,38 @@
   <package id="GDAL.Native" version="2.4.4" targetFramework="net45" />
   <package id="GDAL.Plugins" version="2.4.4" targetFramework="net45" />
   <package id="Grasshopper" version="6.32.20340.21001" targetFramework="net45" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="6.0.1" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.FileExtensions" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Json" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.UserSecrets" version="6.0.1" targetFramework="net48" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.FileProviders.Physical" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.FileSystemGlobbing" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Options" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="6.0.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Primitives" version="6.0.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net45" />
   <package id="OsmSharp" version="6.2.0" targetFramework="net45" />
   <package id="protobuf-net" version="2.3.7" targetFramework="net45" />
   <package id="RhinoCommon" version="6.32.20340.21001" targetFramework="net45" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.IO" version="4.3.0" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net48" />
+  <package id="System.Text.Json" version="6.0.2" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" requireReinstallation="true" />
   <package id="Unofficial.laszip.net" version="2.2.0" targetFramework="net45" />
 </packages>

--- a/Heron/packages.config
+++ b/Heron/packages.config
@@ -8,6 +8,6 @@
   <package id="OsmSharp" version="6.2.0" targetFramework="net45" />
   <package id="protobuf-net" version="2.3.7" targetFramework="net45" />
   <package id="RhinoCommon" version="6.32.20340.21001" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" requireReinstallation="true" />
   <package id="Unofficial.laszip.net" version="2.2.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
In response to OpenTopography.org requiring an API key to download their datasets used in RESTTopo, I've added the ability to maintain UserSecrets separate from the github repo based on the following example:
https://www.frakkingsweet.com/add-usersecrets-to-net-core-console-application/

This approach will allow arbitrary key/values for API keys and tokens with other endpoints as needed.

The UserSecrets functionality required the addition of the associated Microsoft.Extensions nuget packages and an upgrade to .NET Framework 4.8 